### PR TITLE
Removing Sonar secrets configuration from all the repos as automatic sonar scanning is enabled for eclipse-ecsp project

### DIFF
--- a/otterdog/eclipse-ecsp.jsonnet
+++ b/otterdog/eclipse-ecsp.jsonnet
@@ -22,11 +22,6 @@ orgs.newOrg('automotive.ecsp', 'eclipse-ecsp') {
       workflows+: {
         default_workflow_permissions: "write",
       },
-      secrets: [
-        orgs.newRepoSecret('SONAR_TOKEN') {
-          value: "pass:bots/automotive.ecsp/sonarcloud.io/token-ecsp-website",
-        },
-      ],
     },
     orgs.newRepo('entities') {
       allow_merge_commit: true,
@@ -37,11 +32,6 @@ orgs.newOrg('automotive.ecsp', 'eclipse-ecsp') {
       workflows+: {
         default_workflow_permissions: "write",
       },
-      secrets: [
-        orgs.newRepoSecret('SONAR_TOKEN') {
-          value: "pass:bots/automotive.ecsp/sonarcloud.io/token-entities",
-        },
-      ],
     },
     orgs.newRepo('androidVehicleConnectSDK') {
       allow_merge_commit: true,
@@ -52,11 +42,6 @@ orgs.newOrg('automotive.ecsp', 'eclipse-ecsp') {
       workflows+: {
         default_workflow_permissions: "write",
       },
-      secrets: [
-        orgs.newRepoSecret('SONAR_TOKEN') {
-          value: "pass:bots/automotive.ecsp/sonarcloud.io/token-androidVehicleConnectSDK",
-        },
-      ],
     },
     orgs.newRepo('androidVehicleConnectApp') {
       allow_merge_commit: true,
@@ -67,11 +52,6 @@ orgs.newOrg('automotive.ecsp', 'eclipse-ecsp') {
       workflows+: {
         default_workflow_permissions: "write",
       },
-      secrets: [
-        orgs.newRepoSecret('SONAR_TOKEN') {
-          value: "pass:bots/automotive.ecsp/sonarcloud.io/token-androidVehicleConnectApp",
-        },
-      ],
     },
     orgs.newRepo('iOSVehicleConnectSDK') {
       allow_merge_commit: true,
@@ -82,11 +62,6 @@ orgs.newOrg('automotive.ecsp', 'eclipse-ecsp') {
       workflows+: {
         default_workflow_permissions: "write",
       },
-      secrets: [
-        orgs.newRepoSecret('SONAR_TOKEN') {
-          value: "pass:bots/automotive.ecsp/sonarcloud.io/token-iOSVehicleConnectSDK",
-        },
-      ],
     },
     orgs.newRepo('iOSVehicleConnectApp') {
       allow_merge_commit: true,
@@ -97,11 +72,6 @@ orgs.newOrg('automotive.ecsp', 'eclipse-ecsp') {
       workflows+: {
         default_workflow_permissions: "write",
       },
-      secrets: [
-        orgs.newRepoSecret('SONAR_TOKEN') {
-          value: "pass:bots/automotive.ecsp/sonarcloud.io/token-iOSVehicleConnectApp",
-        },
-      ],
     },
   ],
 }

--- a/otterdog/eclipse-ecsp.jsonnet
+++ b/otterdog/eclipse-ecsp.jsonnet
@@ -43,5 +43,20 @@ orgs.newOrg('automotive.ecsp', 'eclipse-ecsp') {
         },
       ],
     },
+    orgs.newRepo('androidVehicleConnectSDK') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "ECSP Android VehicleConnect SDK",
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+      secrets: [
+        orgs.newRepoSecret('SONAR_TOKEN') {
+          value: "pass:bots/automotive.ecsp/sonarcloud.io/token-androidVehicleConnectSDK",
+        },
+      ],
+    },
   ],
 }


### PR DESCRIPTION
Removing Sonar secrets configuration from all the repos as automatic sonar scanning is enabled for eclipse-ecsp project